### PR TITLE
修改协程库在Scheduler多余的else判断断言逻辑

### DIFF
--- a/fiber_lib/3scheduler/scheduler.cpp
+++ b/fiber_lib/3scheduler/scheduler.cpp
@@ -180,10 +180,11 @@ void Scheduler::stop()
     {
         assert(GetThis() == this);
     } 
-    else 
-    {
-        assert(GetThis() != this);
-    }
+	//冗余判断
+    // else 
+    // {
+    //     assert(GetThis() != this);
+    // }
 	
 	for (size_t i = 0; i < m_threadCount; i++) 
 	{


### PR DESCRIPTION
主要群里反馈这里出现了冗余的else判断逻辑，其根本上不会走到这个else所以直接注释